### PR TITLE
add toolchain file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ RUST_LOG={ error | warn | info | debug | trace | off } cargo run -- --app <path_
 
 To visually debug the decision tree used during Wasm bytecode emission:
 ```shell
-cargo run -- vis-tree --whammy <path_to_whammy>
+cargo run -- vis-whammy --whammy <path_to_whammy>
 ```
 
 ## Available Packages ##

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.76.0"
+components = ["rustc", "cargo", "rustfmt", "clippy"]


### PR DESCRIPTION
I encountered this error first building the project
```
error: package `clap_derive v4.5.4` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.69.0
Either upgrade to rustc 1.74 or newer, or use
cargo update -p clap_derive@4.5.4 --precise ver
where `ver` is the latest version of `clap_derive` supporting rustc 1.69.0
```
I think it would be nice if the rust version is specified. (I think if rust is installed via `rustup`, it will automatically recognize this `toml` file and use the correct cargo version while not changing cargo version globally)

PS: https://github.com/wasmerio/wasmer seems to have this convention

I also updated README due to this commit (`vis-tree` is changed to `vis-whammy`)
 https://github.com/ejrgilbert/whamm/commit/6acf103fc83878ce8c6f5babb62053ea37e0d403#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL111