### PR TITLE
print full ast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,8 @@ use cli::{Cmd, WhammCli};
 use crate::parser::whamm_parser::*;
 use crate::behavior::builder_visitor::*;
 use crate::generator::emitters::{Emitter, WasmRewritingEmitter};
-use crate::generator::init_generator::{InitGenerator};
-use crate::generator::instr_generator::{InstrGenerator};
+use crate::generator::init_generator::InitGenerator;
+use crate::generator::instr_generator::InstrGenerator;
 use crate::common::error::ErrorGen;
 
 mod cli;

--- a/src/parser/print_visitor.rs
+++ b/src/parser/print_visitor.rs
@@ -233,10 +233,8 @@ impl WhammVisitor<String> for AsStrVisitor {
                 self.increase_indent();
                 s += &format!("{} {}: ", self.get_indent(), name);
 
-                s += &format!("(");
-                for probe in probes.iter() {
-                    self.visit_probe(probe);
-                }
+                s += &format!("({}", NL);
+                s += &probes.iter().map(|probe| self.visit_probe(probe)).collect::<String>();
                 s += &format!("){}", NL);
                 self.decrease_indent();
             }
@@ -273,7 +271,12 @@ impl WhammVisitor<String> for AsStrVisitor {
         s += &format!("{} `predicate`:{}", self.get_indent(), NL);
         self.increase_indent();
         match &probe.predicate {
-            Some(pred) => s += &format!("{} / {} /{}", self.get_indent(), self.visit_expr(pred), NL),
+            Some(pred) => {
+                let expr = self.visit_expr(pred);
+                expr.split("&&").for_each(|line| {
+                    s += &format!("{}&& {}{}", self.get_indent(), line, NL)
+                });
+            },
             None => s += &format!("{} / None /{}", self.get_indent(), NL)
         }
         self.decrease_indent();
@@ -369,9 +372,7 @@ impl WhammVisitor<String> for AsStrVisitor {
                 s += &format!("{}(", self.visit_expr(fn_target));
                 match args {
                     Some(args) => {
-                        for arg in args {
-                            s += &format!("{}, ", self.visit_expr(arg));
-                        }
+                        s += &args.iter().map(|arg| self.visit_expr(arg)).collect::<Vec<String>>().join(", ");
                     },
                     _ => {}
                 }
@@ -445,9 +446,7 @@ impl WhammVisitor<String> for AsStrVisitor {
             Value::Tuple {ty: _ty, vals} => {
                 let mut s = "".to_string();
                 s += &format!("(");
-                for v in vals.iter() {
-                    s += &format!("{}, ", self.visit_expr(v));
-                }
+                s += &vals.iter().map(|arg| self.visit_expr(arg)).collect::<Vec<String>>().join(", ");
                 s += &format!(")");
                 s
             }

--- a/src/parser/print_visitor.rs
+++ b/src/parser/print_visitor.rs
@@ -446,7 +446,7 @@ impl WhammVisitor<String> for AsStrVisitor {
             Value::Tuple {ty: _ty, vals} => {
                 let mut s = "".to_string();
                 s += &format!("(");
-                s += &vals.iter().map(|arg| self.visit_expr(arg)).collect::<Vec<String>>().join(", ");
+                s += &vals.iter().map(|v| self.visit_expr(v)).collect::<Vec<String>>().join(", ");
                 s += &format!(")");
                 s
             }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -47,7 +47,7 @@ const VALID_SCRIPTS: &'static [&'static str] = &[
 
     // Function calls
     r#"
-wasm::call:alt / strpaircmp((arg2, arg3), "record") / {
+wasm::call:alt / strcmp((arg2, arg3), "record") / {
     new_target_fn_name = "redirect_to_fault_injector";
 }
     "#,
@@ -56,17 +56,22 @@ wasm::call:alt /
     target_fn_type == "import" &&
     target_imp_module == "ic0" &&
     target_imp_name == "call_new" &&
-    strpaircmp((arg0, arg1), "bookings") &&
-    strpaircmp((arg2, arg3), "record")
+    strcmp((arg0, arg1), "bookings") &&
+    strcmp((arg2, arg3), "record")
 / {
     new_target_fn_name = "redirect_to_fault_injector";
 }
     "#,
 
-    // Statements
+    // Statements (either assignment or function call)
     r#"
     wasm:bytecode:br:before {
         i = 0;
+    }
+    "#,
+    r#"
+    wasm:bytecode:br:before {
+        call_new();
     }
     "#,
 
@@ -228,8 +233,8 @@ wasm::call:alt /
     target_fn_type == "import" &&
     target_imp_module == "ic0" &&
     target_imp_name == "call_new" &&
-    strpaircmp((arg0, arg1), "bookings") &&
-    strpaircmp((arg2, arg3), "record")
+    strcmp((arg0, arg1), "bookings") &&
+    strcmp((arg2, arg3), "record")
 / {
     new_target_fn_name = "redirect_to_fault_injector";
 }

--- a/src/parser/whamm_parser.rs
+++ b/src/parser/whamm_parser.rs
@@ -6,7 +6,7 @@ use pest::error::{Error, LineColLocation};
 use pest::Parser;
 use pest::iterators::{Pair, Pairs};
 
-use log::{trace};
+use log::trace;
 use crate::common::error::{ErrorGen, WhammError};
 use crate::parser::types::{DataType, Script, Whamm, Expr, Statement, Value, Location, ProbeSpec, SpecPart};
 

--- a/src/verifier/tests.rs
+++ b/src/verifier/tests.rs
@@ -51,8 +51,8 @@ wasm::call:alt /
     target_fn_type == "import" &&
     target_imp_module == "ic0" &&
     target_imp_name == "call_new" &&
-    strpaircmp((arg0, arg1), "bookings") &&
-    strpaircmp((arg2, arg3), "record")
+    strcmp((arg0, arg1), "bookings") &&
+    strcmp((arg2, arg3), "record")
 / {
     new_target_fn_name = "redirect_to_fault_injector";
 }


### PR DESCRIPTION
The previous `print_ast` function does not [add the content in the probe](https://github.com/ejrgilbert/whamm/compare/master...ahuoguo:print-full-ast?expand=1#diff-0ce042aa2df7dda2b1811fe9fb0227c7f52b801b9f97b3cfddfea6b0164c9985L238) to the AST.

I also fixed some formatting errors `strcmp((arg2, arg3, ), "record", )` (the extra commas after the last expression) and applied some clippy suggestions.