### PR TITLE
Support `alloc` vars

### DIFF
--- a/src/common/instr.rs
+++ b/src/common/instr.rs
@@ -24,6 +24,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::exit;
 use wasmparser::MemoryType;
+use crate::emitter::InjectStrategy;
 
 /// create output path if it doesn't exist
 pub(crate) fn try_path(path: &String) {
@@ -252,6 +253,7 @@ fn run_instr_wizard(
     let mut injected_funcs = vec![];
     let mut gen = crate::generator::wizard::WizardGenerator {
         emitter: ModuleEmitter::new(
+            InjectStrategy::Wizard,
             target_wasm,
             symbol_table,
             &mut mem_tracker,
@@ -284,6 +286,7 @@ fn run_instr_rewrite(
     let mut injected_funcs = vec![];
     let mut init = InitGenerator {
         emitter: ModuleEmitter::new(
+            InjectStrategy::Rewriting,
             target_wasm,
             symbol_table,
             &mut mem_tracker,
@@ -303,6 +306,7 @@ fn run_instr_rewrite(
     // and ready to use in every body/predicate.
     let mut instr = InstrGenerator::new(
         VisitingEmitter::new(
+            InjectStrategy::Rewriting,
             target_wasm,
             &injected_funcs,
             symbol_table,

--- a/src/common/instr.rs
+++ b/src/common/instr.rs
@@ -4,6 +4,7 @@ use crate::common::error::ErrorGen;
 use crate::emitter::module_emitter::{MemoryTracker, ModuleEmitter};
 use crate::emitter::report_var_metadata::ReportVarMetadata;
 use crate::emitter::rewriting::visiting_emitter::VisitingEmitter;
+use crate::emitter::InjectStrategy;
 use crate::generator::rewriting::init_generator::InitGenerator;
 use crate::generator::rewriting::instr_generator::InstrGenerator;
 use crate::generator::rewriting::simple_ast::{build_simple_ast, SimpleAST};
@@ -24,7 +25,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::exit;
 use wasmparser::MemoryType;
-use crate::emitter::InjectStrategy;
 
 /// create output path if it doesn't exist
 pub(crate) fn try_path(path: &String) {

--- a/src/emitter/mod.rs
+++ b/src/emitter/mod.rs
@@ -9,6 +9,12 @@ use crate::common::error::ErrorGen;
 use crate::emitter::rewriting::rules::Arg;
 use crate::parser::types::{Block, Expr, Statement};
 
+#[derive(Copy, Clone)]
+pub enum InjectStrategy {
+    Wizard,
+    Rewriting
+}
+
 // =================================================
 // ==== Emitter Trait --> Used By All Emitters! ====
 // =================================================

--- a/src/emitter/mod.rs
+++ b/src/emitter/mod.rs
@@ -6,8 +6,15 @@ pub mod tests;
 pub mod utils;
 
 use crate::common::error::ErrorGen;
+use crate::emitter::report_var_metadata::{Metadata, ReportVarMetadata};
 use crate::emitter::rewriting::rules::Arg;
+use crate::lang_features::libraries::core::io::io_adapter::IOAdapter;
+use crate::lang_features::libraries::core::maps::map_adapter::MapLibAdapter;
 use crate::parser::types::{Block, Expr, Statement};
+use crate::verifier::types::{Record, SymbolTable};
+use orca_wasm::ir::id::{FunctionID, GlobalID};
+use orca_wasm::{Module, Opcode};
+use std::collections::HashMap;
 
 #[derive(Copy, Clone)]
 pub enum InjectStrategy {
@@ -28,4 +35,144 @@ pub trait Emitter {
         err: &mut ErrorGen,
     ) -> bool;
     fn emit_expr(&mut self, expr: &mut Expr, err: &mut ErrorGen) -> bool;
+}
+
+/// This should run AFTER emitting the full AST
+pub fn configure_flush_routines(
+    wasm: &mut Module,
+    table: &mut SymbolTable,
+    report_var_metadata: &mut ReportVarMetadata,
+    map_lib_adapter: &mut MapLibAdapter,
+    io_adapter: &mut IOAdapter,
+    err_msg: &str,
+    err: &mut ErrorGen,
+) {
+    if report_var_metadata.variable_metadata.is_empty()
+        && report_var_metadata.map_metadata.is_empty()
+    {
+        return;
+    }
+
+    //convert the metadata into strings, add those to the data section, then use those to populate the maps
+    let var_meta: HashMap<u32, String> = report_var_metadata
+        .variable_metadata
+        .iter()
+        .map(|(key, value)| (*key, value.to_csv()))
+        .collect();
+    let map_meta: HashMap<u32, String> = report_var_metadata
+        .map_metadata
+        .iter()
+        .map(|(key, value)| (*key, value.to_csv()))
+        .collect();
+
+    setup_print_global_meta(&var_meta, wasm, table, io_adapter, err_msg, err);
+    if map_lib_adapter.is_used {
+        setup_print_map_meta(
+            &map_meta,
+            wasm,
+            table,
+            io_adapter,
+            map_lib_adapter,
+            err_msg,
+            err,
+        );
+    }
+}
+
+/// set up the print_global_meta function for insertions
+fn setup_print_global_meta(
+    var_meta_str: &HashMap<u32, String>,
+    wasm: &mut Module,
+    table: &mut SymbolTable,
+    io_adapter: &mut IOAdapter,
+    err_msg: &str,
+    err: &mut ErrorGen,
+) -> bool {
+    // get the function
+    // todo(maps) -- look up the func name instead!
+    let print_global_meta_id = if let Some(Record::Fn { addr: Some(id), .. }) =
+        table.lookup_fn("print_global_meta", true, err)
+    {
+        *id
+    } else {
+        return false;
+    };
+    let print_global_meta_id = FunctionID(print_global_meta_id);
+
+    let mut print_global_meta = match wasm.functions.get_fn_modifier(print_global_meta_id) {
+        Some(func) => func,
+        None => {
+            err.unexpected_error(
+                true,
+                Some(format!(
+                    "{err_msg} \
+                    No 'print_global_meta' function found in the module!"
+                )),
+                None,
+            );
+            return false;
+        }
+    };
+
+    // output the header data segment
+    let header = Metadata::get_csv_header();
+    io_adapter.putsln(header.clone(), &mut print_global_meta, err);
+
+    // for each of the report globals, emit the printing logic
+    for (key, val) in var_meta_str.iter() {
+        io_adapter.puts(format!("i32,{key},{val},"), &mut print_global_meta, err);
+
+        // get the value of this report global
+        print_global_meta.global_get(GlobalID(*key));
+        io_adapter.call_puti(&mut print_global_meta, err);
+        io_adapter.putln(&mut print_global_meta, err);
+    }
+    true
+}
+
+fn setup_print_map_meta(
+    map_meta_str: &HashMap<u32, String>,
+    wasm: &mut Module,
+    table: &mut SymbolTable,
+    io_adapter: &mut IOAdapter,
+    map_lib_adapter: &mut MapLibAdapter,
+    err_msg: &str,
+    err: &mut ErrorGen,
+) -> bool {
+    // get the function
+    //first, we need to create the maps in global_map_init - where all the other maps are initialized
+    // todo(maps) -- look up the func name instead!
+    let print_map_meta_id = if let Some(Record::Fn { addr: Some(id), .. }) =
+        table.lookup_fn("print_map_meta", true, err)
+    {
+        *id
+    } else {
+        return false;
+    };
+    let print_map_meta_id = FunctionID(print_map_meta_id);
+
+    let mut print_map_meta = match wasm.functions.get_fn_modifier(print_map_meta_id) {
+        Some(func) => func,
+        None => {
+            err.unexpected_error(
+                true,
+                Some(format!(
+                    "{err_msg} \
+                    No 'print_map_meta' function found in the module!"
+                )),
+                None,
+            );
+            return false;
+        }
+    };
+
+    // for each of the report maps, emit the printing logic
+    for (key, val) in map_meta_str.iter() {
+        io_adapter.puts(format!("map,{key},{val},"), &mut print_map_meta, err);
+
+        // print the value(s) of this map
+        map_lib_adapter.print_map(*key, &mut print_map_meta, err);
+        io_adapter.putln(&mut print_map_meta, err);
+    }
+    true
 }

--- a/src/emitter/mod.rs
+++ b/src/emitter/mod.rs
@@ -12,7 +12,7 @@ use crate::parser::types::{Block, Expr, Statement};
 #[derive(Copy, Clone)]
 pub enum InjectStrategy {
     Wizard,
-    Rewriting
+    Rewriting,
 }
 
 // =================================================

--- a/src/emitter/module_emitter.rs
+++ b/src/emitter/module_emitter.rs
@@ -1,8 +1,8 @@
 use crate::common::error::{ErrorGen, WhammError};
-use crate::emitter::report_var_metadata::{Metadata, ReportVarMetadata};
+use crate::emitter::report_var_metadata::ReportVarMetadata;
 use crate::emitter::rewriting::rules::Arg;
 use crate::emitter::utils::{emit_body, emit_expr, emit_stmt, whamm_type_to_wasm_global};
-use crate::emitter::{Emitter, InjectStrategy};
+use crate::emitter::{configure_flush_routines, Emitter, InjectStrategy};
 use crate::lang_features::alloc_vars::rewriting::AllocVarHandler;
 use crate::lang_features::libraries::core::io::io_adapter::IOAdapter;
 use crate::lang_features::libraries::core::maps::map_adapter::MapLibAdapter;
@@ -659,130 +659,16 @@ impl<'a, 'b, 'c, 'd, 'e, 'f, 'g> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f, 'g> {
         self.emit_global_inner(name, ty, val, true, err)
     }
 
-    /// This should run BEFORE emitting the full AST
-
-    /// This should run AFTER emitting the full AST
     pub fn configure_flush_routines(&mut self, io_adapter: &mut IOAdapter, err: &mut ErrorGen) {
-        // configure the flushing routines!
-        let report_var_metadata = &self.report_var_metadata;
-        if report_var_metadata.variable_metadata.is_empty()
-            && report_var_metadata.map_metadata.is_empty()
-        {
-            return;
-        }
-
-        //convert the metadata into strings, add those to the data section, then use those to populate the maps
-        let var_meta: HashMap<u32, String> = report_var_metadata
-            .variable_metadata
-            .iter()
-            .map(|(key, value)| (*key, value.to_csv()))
-            .collect();
-        let map_meta: HashMap<u32, String> = report_var_metadata
-            .map_metadata
-            .iter()
-            .map(|(key, value)| (*key, value.to_csv()))
-            .collect();
-
-        self.setup_print_global_meta(&var_meta, io_adapter, err);
-        self.setup_print_map_meta(&map_meta, io_adapter, err);
-    }
-
-    /// set up the print_global_meta function for insertions
-    fn setup_print_global_meta(
-        &mut self,
-        var_meta_str: &HashMap<u32, String>,
-        io_adapter: &mut IOAdapter,
-        err: &mut ErrorGen,
-    ) -> bool {
-        // get the function
-        // todo(maps) -- look up the func name instead!
-        let print_global_meta_id = if let Some(Record::Fn { addr: Some(id), .. }) =
-            self.table.lookup_fn("print_global_meta", err)
-        {
-            *id
-        } else {
-            return false;
-        };
-        let print_global_meta_id = FunctionID(print_global_meta_id);
-
-        let mut print_global_meta = match self
-            .app_wasm
-            .functions
-            .get_fn_modifier(print_global_meta_id)
-        {
-            Some(func) => func,
-            None => {
-                err.unexpected_error(
-                    true,
-                    Some(format!(
-                        "{UNEXPECTED_ERR_MSG} \
-                    No 'print_global_meta' function found in the module!"
-                    )),
-                    None,
-                );
-                return false;
-            }
-        };
-
-        // output the header data segment
-        let header = Metadata::get_csv_header();
-        io_adapter.putsln(header.clone(), &mut print_global_meta, err);
-
-        // for each of the report globals, emit the printing logic
-        for (key, val) in var_meta_str.iter() {
-            io_adapter.puts(format!("i32,{key},{val},"), &mut print_global_meta, err);
-
-            // get the value of this report global
-            print_global_meta.global_get(GlobalID(*key));
-            io_adapter.call_puti(&mut print_global_meta, err);
-            io_adapter.putln(&mut print_global_meta, err);
-        }
-        true
-    }
-
-    fn setup_print_map_meta(
-        &mut self,
-        map_meta_str: &HashMap<u32, String>,
-        io_adapter: &mut IOAdapter,
-        err: &mut ErrorGen,
-    ) -> bool {
-        // get the function
-        //first, we need to create the maps in global_map_init - where all the other maps are initialized
-        // todo(maps) -- look up the func name instead!
-        let print_map_meta_id = if let Some(Record::Fn { addr: Some(id), .. }) =
-            self.table.lookup_fn("print_map_meta", err)
-        {
-            *id
-        } else {
-            return false;
-        };
-        let print_map_meta_id = FunctionID(print_map_meta_id);
-
-        let mut print_map_meta = match self.app_wasm.functions.get_fn_modifier(print_map_meta_id) {
-            Some(func) => func,
-            None => {
-                err.unexpected_error(
-                    true,
-                    Some(format!(
-                        "{UNEXPECTED_ERR_MSG} \
-                    No 'print_map_meta' function found in the module!"
-                    )),
-                    None,
-                );
-                return false;
-            }
-        };
-
-        // for each of the report maps, emit the printing logic
-        for (key, val) in map_meta_str.iter() {
-            io_adapter.puts(format!("map,{key},{val},"), &mut print_map_meta, err);
-
-            // print the value(s) of this map
-            self.map_lib_adapter
-                .print_map(*key, &mut print_map_meta, err);
-            io_adapter.putln(&mut print_map_meta, err);
-        }
-        true
+        configure_flush_routines(
+            self.app_wasm,
+            self.table,
+            self.report_var_metadata,
+            self.map_lib_adapter,
+            io_adapter,
+            UNEXPECTED_ERR_MSG,
+            err,
+        );
     }
 }
 impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_, '_> {

--- a/src/emitter/module_emitter.rs
+++ b/src/emitter/module_emitter.rs
@@ -2,7 +2,7 @@ use crate::common::error::{ErrorGen, WhammError};
 use crate::emitter::report_var_metadata::{Metadata, ReportVarMetadata};
 use crate::emitter::rewriting::rules::Arg;
 use crate::emitter::utils::{emit_body, emit_expr, emit_stmt, whamm_type_to_wasm_global};
-use crate::emitter::Emitter;
+use crate::emitter::{Emitter, InjectStrategy};
 use crate::lang_features::libraries::core::io::io_adapter::IOAdapter;
 use crate::lang_features::libraries::core::maps::map_adapter::MapLibAdapter;
 use crate::parser::types::{Block, DataType, Definition, Expr, Fn, FnId, Statement, Value};
@@ -34,6 +34,7 @@ pub struct StringAddr {
 }
 
 pub struct ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
+    pub strategy: InjectStrategy,
     pub app_wasm: &'a mut Module<'b>,
     pub emitting_func: Option<FunctionBuilder<'b>>,
     pub table: &'c mut SymbolTable,
@@ -46,6 +47,7 @@ pub struct ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
 impl<'a, 'b, 'c, 'd, 'e, 'f> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
     // note: only used in integration test
     pub fn new(
+        strategy: InjectStrategy,
         app_wasm: &'a mut Module<'b>,
         table: &'c mut SymbolTable,
         mem_tracker: &'d mut MemoryTracker,
@@ -53,6 +55,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
         report_var_metadata: &'f mut ReportVarMetadata,
     ) -> Self {
         Self {
+            strategy,
             app_wasm,
             emitting_func: None,
             mem_tracker,
@@ -788,6 +791,7 @@ impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
         if let Some(emitting_func) = &mut self.emitting_func {
             emit_body(
                 body,
+                self.strategy,
                 emitting_func,
                 self.table,
                 self.mem_tracker,
@@ -810,6 +814,7 @@ impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
         if let Some(emitting_func) = &mut self.emitting_func {
             emit_stmt(
                 stmt,
+                self.strategy,
                 emitting_func,
                 self.table,
                 self.mem_tracker,
@@ -827,6 +832,7 @@ impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
         if let Some(emitting_func) = &mut self.emitting_func {
             emit_expr(
                 expr,
+                self.strategy,
                 emitting_func,
                 self.table,
                 self.mem_tracker,

--- a/src/emitter/module_emitter.rs
+++ b/src/emitter/module_emitter.rs
@@ -3,6 +3,7 @@ use crate::emitter::report_var_metadata::{Metadata, ReportVarMetadata};
 use crate::emitter::rewriting::rules::Arg;
 use crate::emitter::utils::{emit_body, emit_expr, emit_stmt, whamm_type_to_wasm_global};
 use crate::emitter::{Emitter, InjectStrategy};
+use crate::lang_features::alloc_vars::rewriting::AllocVarHandler;
 use crate::lang_features::libraries::core::io::io_adapter::IOAdapter;
 use crate::lang_features::libraries::core::maps::map_adapter::MapLibAdapter;
 use crate::parser::types::{Block, DataType, Definition, Expr, Fn, FnId, Statement, Value};
@@ -33,7 +34,7 @@ pub struct StringAddr {
     pub len: usize,
 }
 
-pub struct ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
+pub struct ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f, 'g> {
     pub strategy: InjectStrategy,
     pub app_wasm: &'a mut Module<'b>,
     pub emitting_func: Option<FunctionBuilder<'b>>,
@@ -41,10 +42,11 @@ pub struct ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
     mem_tracker: &'d mut MemoryTracker,
     pub map_lib_adapter: &'e mut MapLibAdapter,
     pub report_var_metadata: &'f mut ReportVarMetadata,
+    pub alloc_var_handler: &'g mut AllocVarHandler,
     fn_providing_contexts: Vec<String>,
 }
 
-impl<'a, 'b, 'c, 'd, 'e, 'f> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
+impl<'a, 'b, 'c, 'd, 'e, 'f, 'g> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f, 'g> {
     // note: only used in integration test
     pub fn new(
         strategy: InjectStrategy,
@@ -53,6 +55,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
         mem_tracker: &'d mut MemoryTracker,
         map_lib_adapter: &'e mut MapLibAdapter,
         report_var_metadata: &'f mut ReportVarMetadata,
+        alloc_var_handler: &'g mut AllocVarHandler,
     ) -> Self {
         Self {
             strategy,
@@ -61,6 +64,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
             mem_tracker,
             map_lib_adapter,
             report_var_metadata,
+            alloc_var_handler,
             table,
             fn_providing_contexts: vec!["whamm".to_string()],
         }
@@ -781,7 +785,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f> {
         true
     }
 }
-impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
+impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_, '_> {
     fn emit_body(
         &mut self,
         _curr_instr_args: &[Arg],
@@ -797,6 +801,7 @@ impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
                 self.mem_tracker,
                 self.map_lib_adapter,
                 self.report_var_metadata,
+                self.alloc_var_handler,
                 UNEXPECTED_ERR_MSG,
                 err,
             )
@@ -820,6 +825,7 @@ impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
                 self.mem_tracker,
                 self.map_lib_adapter,
                 self.report_var_metadata,
+                self.alloc_var_handler,
                 UNEXPECTED_ERR_MSG,
                 err,
             )
@@ -838,6 +844,7 @@ impl Emitter for ModuleEmitter<'_, '_, '_, '_, '_, '_> {
                 self.mem_tracker,
                 self.map_lib_adapter,
                 self.report_var_metadata,
+                self.alloc_var_handler,
                 UNEXPECTED_ERR_MSG,
                 err,
             )

--- a/src/emitter/utils.rs
+++ b/src/emitter/utils.rs
@@ -2,6 +2,7 @@
 use crate::common::error::ErrorGen;
 use crate::emitter::module_emitter::MemoryTracker;
 use crate::emitter::report_var_metadata::ReportVarMetadata;
+use crate::emitter::InjectStrategy;
 use crate::generator::folding::ExprFolder;
 use crate::lang_features::libraries::core::maps::map_adapter::MapLibAdapter;
 use crate::parser::types::{
@@ -13,7 +14,6 @@ use orca_wasm::ir::types::{BlockType, DataType as OrcaType, Value as OrcaValue};
 use orca_wasm::module_builder::AddLocal;
 use orca_wasm::opcode::{MacroOpcode, Opcode};
 use orca_wasm::{InitExpr, Module};
-use crate::emitter::InjectStrategy;
 // ==================================================================
 // ================ Emitter Helper Functions ========================
 // TODO -- add this documentation
@@ -24,7 +24,6 @@ use crate::emitter::InjectStrategy;
 // - with a construction of InstrumentationVisitor inside that loop.
 // ==================================================================
 // ==================================================================
-
 
 // TODO -- make this a struct that contains all the data to be passed around!
 

--- a/src/emitter/utils.rs
+++ b/src/emitter/utils.rs
@@ -865,7 +865,7 @@ pub(crate) fn emit_expr<'a, T: Opcode<'a> + MacroOpcode<'a> + AddLocal>(
                 );
             }
 
-            let Some(Record::Fn { addr, .. }) = table.lookup_fn(&fn_name, err) else {
+            let Some(Record::Fn { addr, .. }) = table.lookup_fn(&fn_name, true, err) else {
                 err.unexpected_error(true, Some("unexpected type".to_string()), None);
                 return false;
             };
@@ -1243,7 +1243,7 @@ pub fn print_report_all<'a, T: Opcode<'a> + AddLocal>(
     }
     let Some(Record::Fn {
         addr: Some(fid), ..
-    }) = table.lookup_fn("print_global_meta", err)
+    }) = table.lookup_fn("print_global_meta", true, err)
     else {
         err.unexpected_error(true, Some("unexpected type".to_string()), None);
         return;
@@ -1252,9 +1252,9 @@ pub fn print_report_all<'a, T: Opcode<'a> + AddLocal>(
 
     let Some(Record::Fn {
         addr: Some(fid), ..
-    }) = table.lookup_fn("print_map_meta", err)
+    }) = table.lookup_fn("print_map_meta", false, err)
     else {
-        err.unexpected_error(true, Some("unexpected type".to_string()), None);
+        // maps must not be used in this script, ignore
         return;
     };
     injector.call(FunctionID(*fid));

--- a/src/generator/rewriting/init_generator.rs
+++ b/src/generator/rewriting/init_generator.rs
@@ -16,13 +16,13 @@ use orca_wasm::ir::id::FunctionID;
 /// emit some compiler-provided functions and user-defined globals.
 /// This process should ideally be generic, made to perform a specific
 /// instrumentation technique by the Emitter field.
-pub struct InitGenerator<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> {
-    pub emitter: ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f>,
+pub struct InitGenerator<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> {
+    pub emitter: ModuleEmitter<'a, 'b, 'c, 'd, 'e, 'f, 'g>,
     pub context_name: String,
-    pub err: &'g mut ErrorGen,
-    pub injected_funcs: &'h mut Vec<FunctionID>,
+    pub err: &'h mut ErrorGen,
+    pub injected_funcs: &'i mut Vec<FunctionID>,
 }
-impl InitGenerator<'_, '_, '_, '_, '_, '_, '_, '_> {
+impl InitGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
     pub fn run(&mut self, whamm: &mut Whamm) -> bool {
         // Reset the symbol table in the emitter just in case
         self.emitter.reset_table();
@@ -35,7 +35,7 @@ impl InitGenerator<'_, '_, '_, '_, '_, '_, '_, '_> {
     }
 }
 
-impl GeneratingVisitor for InitGenerator<'_, '_, '_, '_, '_, '_, '_, '_> {
+impl GeneratingVisitor for InitGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
     fn emit_string(&mut self, val: &mut Value) -> bool {
         self.emitter.emit_string(val, self.err)
     }

--- a/src/generator/rewriting/instr_generator.rs
+++ b/src/generator/rewriting/instr_generator.rs
@@ -1,6 +1,5 @@
 use crate::common::error::ErrorGen;
-use crate::emitter::module_emitter::StringAddr;
-use crate::emitter::report_var_metadata::{BytecodeLoc, LocationData, Metadata};
+use crate::emitter::report_var_metadata::{BytecodeLoc, LocationData};
 use crate::emitter::rewriting::rules::{provider_factory, Arg, LocInfo, ProbeRule, WhammProvider};
 use crate::emitter::rewriting::visiting_emitter::VisitingEmitter;
 use crate::emitter::Emitter;
@@ -8,13 +7,8 @@ use crate::generator::folding::ExprFolder;
 use crate::generator::rewriting::simple_ast::{SimpleAST, SimpleProbe};
 use crate::parser::rules::core::WhammModeKind;
 use crate::parser::types::{Block, Expr, Value};
-use crate::verifier::types::Record;
-use orca_wasm::ir::id::{FunctionID, GlobalID};
-use orca_wasm::ir::types::Value as OrcaValue;
 use orca_wasm::iterator::iterator_trait::Iterator;
-use orca_wasm::opcode::Instrumenter;
-use orca_wasm::{DataSegment, DataSegmentKind, InitExpr, Opcode};
-use orca_wasm::{Location as OrcaLocation, Location};
+use orca_wasm::Location as OrcaLocation;
 use std::collections::HashMap;
 use std::iter::Iterator as StdIter;
 
@@ -361,205 +355,8 @@ impl<'b> InstrGenerator<'_, 'b, '_, '_, '_, '_, '_, '_> {
             false
         }
     }
-
     fn after_run(&mut self) -> bool {
-        if self
-            .emitter
-            .report_var_metadata
-            .variable_metadata
-            .is_empty()
-            && self.emitter.report_var_metadata.map_metadata.is_empty()
-        {
-            return true;
-        }
-
-        // configure the flushing routines!
-        let report_var_metadata = &self.emitter.report_var_metadata;
-        let var_meta = &report_var_metadata.variable_metadata;
-        let map_meta = &report_var_metadata.map_metadata;
-        let mut var_meta_str: HashMap<u32, String> = HashMap::new();
-        let mut map_meta_str: HashMap<u32, String> = HashMap::new();
-        //convert the metadata into strings, add those to the data section, then use those to populate the maps
-        for (key, value) in var_meta.iter() {
-            //first, emit the string to data section
-            let val = value.to_csv();
-            let data_id = self.emitter.app_iter.module.data.len();
-            let val_bytes = val.as_bytes().to_owned();
-            let data_segment = DataSegment {
-                data: val_bytes,
-                kind: DataSegmentKind::Active {
-                    memory_index: self.emitter.mem_tracker.mem_id,
-                    offset_expr: InitExpr::Value(OrcaValue::I32(
-                        self.emitter.mem_tracker.curr_mem_offset as i32,
-                    )),
-                },
-            };
-            self.emitter.app_iter.module.data.push(data_segment);
-            // save the memory addresses/lens, so they can be used as appropriate
-            self.emitter.mem_tracker.emitted_strings.insert(
-                val.clone(),
-                StringAddr {
-                    data_id: data_id as u32,
-                    mem_offset: self.emitter.mem_tracker.curr_mem_offset,
-                    len: val.len(),
-                },
-            );
-            // update curr_mem_offset to account for new data
-            self.emitter.mem_tracker.curr_mem_offset += val.len();
-            //now set the new key value for the new maps
-            var_meta_str.insert(*key, val);
-        }
-        for (key, value) in map_meta.iter() {
-            //first, emit the string to data section
-            let val = value.to_csv();
-            let data_id = self.emitter.app_iter.module.data.len();
-            let val_bytes = val.as_bytes().to_owned();
-            let data_segment = DataSegment {
-                data: val_bytes,
-                kind: DataSegmentKind::Active {
-                    memory_index: self.emitter.mem_tracker.mem_id,
-                    offset_expr: InitExpr::Value(OrcaValue::I32(
-                        self.emitter.mem_tracker.curr_mem_offset as i32,
-                    )),
-                },
-            };
-            self.emitter.app_iter.module.data.push(data_segment);
-            // save the memory addresses/lens, so they can be used as appropriate
-            self.emitter.mem_tracker.emitted_strings.insert(
-                val.clone(),
-                StringAddr {
-                    data_id: data_id as u32,
-                    mem_offset: self.emitter.mem_tracker.curr_mem_offset,
-                    len: val.len(),
-                },
-            );
-            // update curr_mem_offset to account for new data
-            self.emitter.mem_tracker.curr_mem_offset += val.len();
-            //now set the new key value for the new maps
-            map_meta_str.insert(*key, val);
-        }
-        let mut is_success = self.setup_print_global_meta(&var_meta_str);
-        is_success &= self.setup_print_map_meta(&map_meta_str);
-        is_success
-    }
-
-    /// set up the print_global_meta function for insertions
-    fn setup_print_global_meta(&mut self, var_meta_str: &HashMap<u32, String>) -> bool {
-        // get the function
-        // todo(maps) -- look up the func name instead!
-        let print_global_meta_id = if let Some(Record::Fn { addr: Some(id), .. }) =
-            self.emitter.table.lookup_fn("print_global_meta", self.err)
-        {
-            *id
-        } else {
-            return false;
-        };
-        let print_global_meta_id = FunctionID(print_global_meta_id);
-
-        let mut print_global_meta = match self
-            .emitter
-            .app_iter
-            .module
-            .functions
-            .get_fn_modifier(print_global_meta_id)
-        {
-            Some(func) => func,
-            None => {
-                self.err.add_error(ErrorGen::get_unexpected_error(
-                    true,
-                    Some(format!(
-                        "{UNEXPECTED_ERR_MSG} \
-                    No 'print_global_meta' function found in the module!"
-                    )),
-                    None,
-                ));
-                return false;
-            }
-        };
-        //now set up the actual module editing
-        print_global_meta.before_at(Location::Module {
-            func_idx: print_global_meta_id, // not used
-            instr_idx: 0,
-        });
-
-        // output the header data segment
-        let header = Metadata::get_csv_header();
-        self.emitter
-            .io_adapter
-            .putsln(header.clone(), &mut print_global_meta, self.err);
-
-        // for each of the report globals, emit the printing logic
-        for (key, val) in var_meta_str.iter() {
-            self.emitter.io_adapter.puts(
-                format!("i32,{key},{val},"),
-                &mut print_global_meta,
-                self.err,
-            );
-
-            // get the value of this report global
-            print_global_meta.global_get(GlobalID(*key));
-            self.emitter
-                .io_adapter
-                .call_puti(&mut print_global_meta, self.err);
-            self.emitter
-                .io_adapter
-                .putln(&mut print_global_meta, self.err);
-        }
-        true
-    }
-    fn setup_print_map_meta(&mut self, map_meta_str: &HashMap<u32, String>) -> bool {
-        // get the function
-        //first, we need to create the maps in global_map_init - where all the other maps are initialized
-        // todo(maps) -- look up the func name instead!
-        let print_map_meta_id = if let Some(Record::Fn { addr: Some(id), .. }) =
-            self.emitter.table.lookup_fn("print_map_meta", self.err)
-        {
-            *id
-        } else {
-            return false;
-        };
-        let print_map_meta_id = FunctionID(print_map_meta_id);
-
-        let mut print_map_meta = match self
-            .emitter
-            .app_iter
-            .module
-            .functions
-            .get_fn_modifier(print_map_meta_id)
-        {
-            Some(func) => func,
-            None => {
-                self.err.add_error(ErrorGen::get_unexpected_error(
-                    true,
-                    Some(format!(
-                        "{UNEXPECTED_ERR_MSG} \
-                    No 'print_map_meta' function found in the module!"
-                    )),
-                    None,
-                ));
-                return false;
-            }
-        };
-        //now set uxp the actual module editing
-        print_map_meta.before_at(Location::Module {
-            func_idx: print_map_meta_id, // not used
-            instr_idx: 0,
-        });
-
-        // for each of the report maps, emit the printing logic
-        for (key, val) in map_meta_str.iter() {
-            self.emitter.io_adapter.puts(
-                format!("map,{key},{val},"),
-                &mut print_map_meta,
-                self.err,
-            );
-
-            // print the value(s) of this map
-            self.emitter
-                .map_lib_adapter
-                .print_map(*key, &mut print_map_meta, self.err);
-            self.emitter.io_adapter.putln(&mut print_map_meta, self.err);
-        }
+        self.emitter.configure_flush_routines(self.err);
         true
     }
 }

--- a/src/generator/rewriting/instr_generator.rs
+++ b/src/generator/rewriting/instr_generator.rs
@@ -168,7 +168,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> InstrGenerator<'a, 'b, 'c, 'd, 'e, 'f, 'g, 
     }
     fn set_curr_loc(&mut self, probe_rule: &ProbeRule, probe: &SimpleProbe) {
         let curr_script_id = probe.script_id.clone();
-        self.emitter.curr_num_reports = probe.num_reports;
+        self.emitter.curr_num_allocs = probe.num_allocs;
         let curr_provider = match &probe_rule.provider {
             Some(provider) => provider.name.clone(),
             None => "".to_string(),
@@ -206,7 +206,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h> InstrGenerator<'a, 'b, 'c, 'd, 'e, 'f, 'g, 
             script_id: curr_script_id,
             bytecode_loc: loc,
             probe_id: curr_probe_id,
-            num_reports: self.emitter.curr_num_reports, //this is still used in the emitter to determine how many new globals to emit
+            num_allocs: self.emitter.curr_num_allocs, //this is still used in the emitter to determine how many new globals to emit
         };
     }
 }

--- a/src/generator/rewriting/simple_ast.rs
+++ b/src/generator/rewriting/simple_ast.rs
@@ -65,16 +65,16 @@ pub struct SimpleProbe {
     pub script_id: String,
     pub predicate: Option<Expr>,
     pub body: Option<Block>,
-    pub num_reports: i32,
+    pub num_allocs: i32,
     pub probe_number: i32,
 }
 impl SimpleProbe {
-    fn new(script_id: String, probe: &dyn Probe, num_reports: i32, probe_number: i32) -> Self {
+    fn new(script_id: String, probe: &dyn Probe, num_allocs: i32, probe_number: i32) -> Self {
         Self {
             script_id,
             predicate: probe.predicate().to_owned(),
             body: probe.body().to_owned(),
-            num_reports,
+            num_allocs,
             probe_number,
         }
     }

--- a/src/generator/rewriting/simple_ast.rs
+++ b/src/generator/rewriting/simple_ast.rs
@@ -302,9 +302,7 @@ impl WhammVisitor<()> for SimpleASTBuilder<'_, '_> {
         trace!("Entering: BehaviorTreeBuilder::visit_stmt");
         // for checking for report_decls
         match stmt {
-            Statement::AllocDecl { .. } => {
-                self.curr_num_allocs += 1
-            }
+            Statement::AllocDecl { .. } => self.curr_num_allocs += 1,
             Statement::If { conseq, alt, .. } => {
                 self.visit_block(conseq);
                 self.visit_block(alt);

--- a/src/generator/wizard/ast.rs
+++ b/src/generator/wizard/ast.rs
@@ -17,7 +17,7 @@ pub struct WizardProbe {
     pub predicate: Option<Expr>,
     pub body: Option<Block>,
     pub metadata: Metadata,
-    pub num_reports: i32,
+    pub num_allocs: i32,
     pub probe_number: i32,
 }
 impl WizardProbe {
@@ -27,12 +27,12 @@ impl WizardProbe {
             predicate: None,
             body: None,
             metadata: Metadata::default(),
-            num_reports: 0,
+            num_allocs: 0,
             probe_number,
         }
     }
-    pub(crate) fn incr_reports(&mut self) {
-        self.num_reports += 1;
+    pub(crate) fn incr_allocs(&mut self) {
+        self.num_allocs += 1;
     }
 }
 

--- a/src/generator/wizard/metadata_collector.rs
+++ b/src/generator/wizard/metadata_collector.rs
@@ -234,10 +234,11 @@ impl WhammVisitor<()> for WizardProbeMetadataCollector<'_, '_, '_> {
             Statement::Decl { .. } => {
                 // ignore
             }
-            Statement::AllocDecl { is_report, .. } => {
-                if *is_report {
-                    self.curr_probe.incr_reports();
-                }
+            Statement::AllocDecl {
+                is_report: _is_report,
+                ..
+            } => {
+                self.curr_probe.incr_allocs();
                 // change this to save off data to allocate
                 todo!()
             }

--- a/src/generator/wizard/mod.rs
+++ b/src/generator/wizard/mod.rs
@@ -15,19 +15,19 @@ use log::trace;
 use orca_wasm::ir::id::FunctionID;
 use orca_wasm::ir::types::DataType as OrcaType;
 
-pub struct WizardGenerator<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i> {
-    pub emitter: ModuleEmitter<'b, 'c, 'd, 'e, 'f, 'g>,
-    pub io_adapter: &'h mut IOAdapter,
+pub struct WizardGenerator<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j> {
+    pub emitter: ModuleEmitter<'b, 'c, 'd, 'e, 'f, 'g, 'h>,
+    pub io_adapter: &'i mut IOAdapter,
     pub context_name: String,
     pub err: &'a mut ErrorGen,
-    pub injected_funcs: &'h mut Vec<FunctionID>,
-    pub config: &'i Config,
+    pub injected_funcs: &'i mut Vec<FunctionID>,
+    pub config: &'j Config,
 
     // tracking
     pub curr_script_id: String,
 }
 
-impl WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
+impl WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
     pub fn run(
         &mut self,
         ast: Vec<WizardScript>,
@@ -164,7 +164,7 @@ impl WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
             script_id: self.curr_script_id.clone(),
             bytecode_loc: BytecodeLoc::new(0, 0), // TODO -- request this from wizard
             probe_id,
-            num_reports: probe.num_reports, //this is still used in the emitter to determine how many new globals to emit
+            num_allocs: probe.num_allocs, //this is still used in the emitter to determine how many new globals to emit
         }
     }
 
@@ -185,11 +185,11 @@ impl WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
             (None, "".to_string())
         };
 
-        // create the probe's report variable globals!
-        for _ in 0..probe.num_reports {
+        // create the probe's alloc variable globals!
+        for _ in 0..probe.num_allocs {
             let (global_id, ..) = whamm_type_to_wasm_global(self.emitter.app_wasm, &DataType::I32);
             self.emitter
-                .report_var_metadata
+                .alloc_var_handler
                 .available_i32_gids
                 .push(*global_id);
         }
@@ -231,7 +231,7 @@ impl WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
     }
 }
 
-impl GeneratingVisitor for WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_> {
+impl GeneratingVisitor for WizardGenerator<'_, '_, '_, '_, '_, '_, '_, '_, '_, '_> {
     // TODO -- these are all duplicates, try to factor out
     fn emit_string(&mut self, val: &mut Value) -> bool {
         self.emitter.emit_string(val, self.err)

--- a/src/lang_features/alloc_vars/rewriting.rs
+++ b/src/lang_features/alloc_vars/rewriting.rs
@@ -1,19 +1,90 @@
+#![allow(clippy::too_many_arguments)]
+use crate::common::error::ErrorGen;
+use crate::emitter::report_var_metadata::ReportVarMetadata;
+use crate::emitter::utils::whamm_type_to_wasm_type;
+use crate::lang_features::libraries::core::maps::map_adapter::MapLibAdapter;
 use crate::parser::types::DataType;
 use crate::verifier::types::VarAddr;
-use std::collections::HashMap;
+use orca_wasm::module_builder::AddLocal;
+use orca_wasm::opcode::MacroOpcode;
+use orca_wasm::Opcode;
 
-pub fn allocate_vars(_to_alloc: Vec<(String, DataType)>) -> HashMap<String, (VarAddr, DataType)> {
-    // Called once per probe match point with `alloc` OR `report` vars.
+#[derive(Default)]
+pub struct AllocVarHandler {
+    pub used_i32_gids: Vec<u32>,
+    pub available_i32_gids: Vec<u32>,
+}
+impl AllocVarHandler {
+    pub fn use_available_gid(&mut self, err_msg: &str, err: &mut ErrorGen) -> Option<u32> {
+        if self.available_i32_gids.is_empty() {
+            err.unexpected_error(
+                true,
+                Some(format!("{err_msg} No available global I32s for alloc vars")),
+                None,
+            );
+            return None;
+        }
+        let id = self.available_i32_gids.remove(0);
+        self.used_i32_gids.push(id);
 
-    // result: The new global variables: name -> (addr, ty)
-    //     as a hashmap to enable caller to place in SymbolTable and handle report variables
-    //   Add these VarAddrs to the symbol table.
-    //   Can now emit the rest of the probe body logic as normal.
+        Some(id)
+    }
+    pub fn allocate_var<'a, T: Opcode<'a> + MacroOpcode<'a> + AddLocal>(
+        &mut self,
+        var_name: &str,
+        ty: &DataType,
+        is_report: bool,
+        addr: &mut Option<VarAddr>,
+        injector: &mut T,
+        map_lib_adapter: &mut MapLibAdapter,
+        report_var_metadata: &mut ReportVarMetadata,
+        err_msg: &str,
+        err: &mut ErrorGen,
+    ) -> bool {
+        if let DataType::Map { .. } = ty {
+            let map_id = if is_report {
+                map_lib_adapter.map_create_report(
+                    var_name.to_string(),
+                    ty.clone(),
+                    injector,
+                    report_var_metadata,
+                    true,
+                    err,
+                )
+            } else {
+                map_lib_adapter.map_create(ty.clone(), injector, err)
+            };
+            *addr = Some(VarAddr::MapId { addr: map_id });
+            return true;
+        }
+        match addr {
+            Some(VarAddr::Global { .. }) | None => {
+                let wasm_ty = whamm_type_to_wasm_type(ty);
+                if let Some(id) = self.use_available_gid(err_msg, err) {
+                    if is_report {
+                        report_var_metadata.put_local_metadata(
+                            id,
+                            var_name.to_string(),
+                            wasm_ty,
+                            err,
+                        );
+                    }
 
-    // NOTE: `decl_init` statements should be run ONCE
-
-    // See utils.rs/`emit_report_decl_stmt`
-    //    basically want to do just refactor to call out to THIS function instead (more modular)
-    //    this function will also handle if the var is a report variable
-    todo!()
+                    *addr = Some(VarAddr::Global { addr: id });
+                    true
+                } else {
+                    false
+                }
+            }
+            Some(VarAddr::Local { .. }) | Some(VarAddr::MapId { .. }) => {
+                //this shouldn't happen for alloc vars - need to err
+                err.unexpected_error(
+                    true,
+                    Some(format!("{err_msg} Expected Global VarAddr.")),
+                    None,
+                );
+                false
+            }
+        }
+    }
 }

--- a/src/verifier/types.rs
+++ b/src/verifier/types.rs
@@ -384,7 +384,7 @@ impl SymbolTable {
             (None, "".to_string())
         }
     }
-    pub fn lookup_fn(&self, key: &str, err: &mut ErrorGen) -> Option<&Record> {
+    pub fn lookup_fn(&self, key: &str, fail_on_miss: bool, err: &mut ErrorGen) -> Option<&Record> {
         if let Some(rec) = self.lookup_rec(key) {
             if matches!(rec, Record::Fn { .. }) {
                 Some(rec)
@@ -393,7 +393,9 @@ impl SymbolTable {
                 None
             }
         } else {
-            err.unexpected_error(true, Some(format!("Could not find fn for: {}", key)), None);
+            if fail_on_miss {
+                err.unexpected_error(true, Some(format!("Could not find fn for: {}", key)), None);
+            }
             None
         }
     }

--- a/tests/scripts/lang_features/report_and_alloc_vars.mm
+++ b/tests/scripts/lang_features/report_and_alloc_vars.mm
@@ -1,0 +1,8 @@
+wasm:opcode:call:before {
+    alloc i32 count;
+    report i32 rep_count;
+
+    count++;
+
+    rep_count = count;
+}

--- a/wasm_playground/example/add_map.mm
+++ b/wasm_playground/example/add_map.mm
@@ -5,17 +5,23 @@ report map<i32, i32> m0;
 // /
 wasm:opcode:call:before
  {
-    if(strcmp((0, 1), "lsdjflaksjdf")) {
-        report i32 c;
-    }
-//     report i32 a;
-//     report map<i32, i32> m;
-//     a = 5;
-    m0[1] = 2;
-//     m[1] = 2;
-//     m[2] = 3;
-    blah = 3;
+    alloc i32 count;
+    report i32 rep_count;
+
+    count++;
+//     if(strcmp((0, 1), "lsdjflaksjdf")) {
+//         report i32 c;
+//     }
+// //     report i32 a;
+// //     report map<i32, i32> m;
+// //     a = 5;
+//     m0[1] = 2;
+// //     m[1] = 2;
+// //     m[2] = 3;
+//     blah = 3;
 //     arg0 = 5;
+
+    rep_count = count;
 }
 // wasm:opcode:call:after /
 //     target_fn_name == "foo"


### PR DESCRIPTION
Parser:
- [x] Extend parser to support new `alloc` keyword
- [x] Test that `alloc`, `alloc report`, `report alloc` all work correctly

Rewriting:
- [x] Logic to allocate the `alloc` variables as globals as emitting a probe at a match site
- [x] Logic to handle `report alloc` variables (make a new `lang_features/report_vars.rs` to put this in one place)

Wizard:
- [ ] Logic to create the `$alloc` function for `alloc` variables that reserves memory
- [ ] Logic to load all `alloc` variables at the start of a probe's body
- [ ] Logic to save all `alloc` variables at the end of a probe's body
- [ ] Logic to handle `report alloc` variables

Test:
- [ ] (wizard) variables that are _only_ `alloc`
- [ ] (wizard) variables that are _only_ `report`
- [ ] (wizard) variables that are _both_ `report` AND `alloc`
- [x] (rewriting) variables that are _only_ `alloc`
- [x] (rewriting) variables that are _only_ `report`
- [x] (rewriting) variables that are _both_ `report` AND `alloc`