### PR TITLE
New monitors for the evaluation

### DIFF
--- a/src/lang_features/libraries/core/maps/map_adapter.rs
+++ b/src/lang_features/libraries/core/maps/map_adapter.rs
@@ -102,11 +102,13 @@ impl MapLibAdapter {
             ("insert_i32_i32".to_string(), 0),
             ("insert_i32_string".to_string(), 0),
             ("insert_string_i32".to_string(), 0),
+            ("insert_i32i32tuple_i32".to_string(), 0),
             ("insert_i32i32i32tuple_i32".to_string(), 0),
             // get from map
             ("get_i32_i32".to_string(), 0),
             ("get_i32_string".to_string(), 0),
             ("get_string_i32".to_string(), 0),
+            ("get_i32i32tuple_i32".to_string(), 0),
             ("get_i32i32i32tuple_i32".to_string(), 0),
             // printing maps
             ("print_map".to_string(), 0),

--- a/tests/scripts/paper_eval/call_graph/app/call_graph.mm.app
+++ b/tests/scripts/paper_eval/call_graph/app/call_graph.mm.app
@@ -1,0 +1,1 @@
+tests/apps/core_suite/handwritten/mem-ops.wasm

--- a/tests/scripts/paper_eval/call_graph/call_graph.mm
+++ b/tests/scripts/paper_eval/call_graph/call_graph.mm
@@ -1,0 +1,24 @@
+// (from, to) -> count
+report var call_graph: map<(u32, u32), u32>;
+var tracking_target: bool;
+var callee: u32;
+
+wasm:opcode:call|return_call:before {
+    call_graph[(fid, imm0)]++;
+}
+
+// TODO:
+// - support `wasm:func:entry`
+// - fix wizard not initializing a global map
+
+// wasm:opcode:*call_indirect|*call_ref:before {
+//     tracking_target = true;
+//     callee = fid;
+// }
+//
+// wasm:func:entry {
+//     if (tracking_target) {
+//         call_graph[(callee, fid)]++;
+//         tracking_target = false;
+//     }
+// }

--- a/tests/scripts/paper_eval/call_graph/expected/rewriting/call_graph.mm.exp
+++ b/tests/scripts/paper_eval/call_graph/expected/rewriting/call_graph.mm.exp
@@ -1,0 +1,3 @@
+================================= REPORT CSV FLUSH ====================================
+id, id_type, name, whamm_type, wasm_type, script_id, fname, fid, pc, probe_id, value(s)
+0, map_id, call_graph, map<(u32,u32),u32>, i32, script0, , , , , (1, 0)->1

--- a/tests/scripts/paper_eval/call_graph/expected/wizard/call_graph.mm.exp
+++ b/tests/scripts/paper_eval/call_graph/expected/wizard/call_graph.mm.exp
@@ -1,0 +1,3 @@
+================================= REPORT CSV FLUSH ====================================
+id, id_type, name, whamm_type, wasm_type, script_id, fname, fid, pc, probe_id, value(s)
+0, map_id, call_graph, map<(u32,u32),u32>, i32, script0, , , , , (1, 0)->1

--- a/tests/scripts/paper_eval/ins_coverage/app/coverage.mm.app
+++ b/tests/scripts/paper_eval/ins_coverage/app/coverage.mm.app
@@ -1,0 +1,1 @@
+tests/apps/core_suite/handwritten/mem-ops.wasm

--- a/tests/scripts/paper_eval/ins_coverage/coverage.mm
+++ b/tests/scripts/paper_eval/ins_coverage/coverage.mm
@@ -1,0 +1,4 @@
+wasm:opcode:*:before {
+    report unshared var reached: bool;
+    reached = true;
+}

--- a/tests/scripts/paper_eval/ins_coverage/expected/rewriting/coverage.mm.exp
+++ b/tests/scripts/paper_eval/ins_coverage/expected/rewriting/coverage.mm.exp
@@ -1,0 +1,11 @@
+
+================================= REPORT CSV FLUSH ====================================
+id, id_type, name, whamm_type, wasm_type, script_id, fname, fid, pc, probe_id, value(s)
+4, memaddr, reached, bool, i32, script0, main, 0, 0, 51_wasm:opcode:i32.const:before, true
+36, memaddr, reached, bool, i32, script0, main, 0, 1, 52_wasm:opcode:i64.const:before, true
+68, memaddr, reached, bool, i32, script0, main, 0, 2, 41_wasm:opcode:i64.store:before, true
+100, memaddr, reached, bool, i32, script0, main, 0, 3, 51_wasm:opcode:i32.const:before, true
+132, memaddr, reached, bool, i32, script0, main, 0, 4, 26_wasm:opcode:i32.load:before, true
+164, memaddr, reached, bool, i32, script0, main, 0, 5, 26_wasm:opcode:i32.load:before, true
+196, memaddr, reached, bool, i32, script0, main, 0, 6, 18_wasm:opcode:drop:before, true
+228, memaddr, reached, bool, i32, script0, start, 1, 0, 14_wasm:opcode:call:before, true

--- a/tests/scripts/paper_eval/ins_coverage/expected/wizard/coverage.mm.exp
+++ b/tests/scripts/paper_eval/ins_coverage/expected/wizard/coverage.mm.exp
@@ -1,0 +1,13 @@
+
+================================= REPORT CSV FLUSH ====================================
+id, id_type, name, whamm_type, wasm_type, script_id, fname, fid, pc, probe_id, value(s)
+4, memaddr, reached, bool, i32, script0, "main", 0, 1, 51_wasm:opcode:i32.const, true
+36, memaddr, reached, bool, i32, script0, "main", 0, 3, 52_wasm:opcode:i64.const, true
+68, memaddr, reached, bool, i32, script0, "main", 0, 5, 41_wasm:opcode:i64.store, true
+100, memaddr, reached, bool, i32, script0, "main", 0, 8, 51_wasm:opcode:i32.const, true
+132, memaddr, reached, bool, i32, script0, "main", 0, 10, 26_wasm:opcode:i32.load, true
+164, memaddr, reached, bool, i32, script0, "main", 0, 13, 26_wasm:opcode:i32.load, true
+196, memaddr, reached, bool, i32, script0, "main", 0, 16, 18_wasm:opcode:drop, true
+228, memaddr, reached, bool, i32, script0, "main", 0, 17, 9_wasm:opcode:end, true
+260, memaddr, reached, bool, i32, script0, "start", 1, 1, 14_wasm:opcode:call, false
+292, memaddr, reached, bool, i32, script0, "start", 1, 3, 9_wasm:opcode:end, false

--- a/tests/scripts/paper_eval/mem_access_tracing/app/mem_access.mm.app
+++ b/tests/scripts/paper_eval/mem_access_tracing/app/mem_access.mm.app
@@ -1,0 +1,1 @@
+tests/apps/core_suite/handwritten/mem-ops.wasm

--- a/tests/scripts/paper_eval/mem_access_tracing/expected/rewriting/mem_access.mm.exp
+++ b/tests/scripts/paper_eval/mem_access_tracing/expected/rewriting/mem_access.mm.exp
@@ -1,0 +1,3 @@
+================================= REPORT CSV FLUSH ====================================
+id, id_type, name, whamm_type, wasm_type, script_id, fname, fid, pc, probe_id, value(s)
+0, map_id, accesses, map<u32,u32>, i32, script0, , , , , 0->1;5->1;8->1

--- a/tests/scripts/paper_eval/mem_access_tracing/expected/wizard/mem_access.mm.exp
+++ b/tests/scripts/paper_eval/mem_access_tracing/expected/wizard/mem_access.mm.exp
@@ -1,0 +1,3 @@
+================================= REPORT CSV FLUSH ====================================
+id, id_type, name, whamm_type, wasm_type, script_id, fname, fid, pc, probe_id, value(s)
+0, map_id, accesses, map<u32,u32>, i32, script0, , , , , 0->1;5->1;8->1

--- a/tests/scripts/paper_eval/mem_access_tracing/mem_access.mm
+++ b/tests/scripts/paper_eval/mem_access_tracing/mem_access.mm
@@ -1,0 +1,5 @@
+report var accesses: map<u32, u32>;
+
+wasm:opcode:*load*|*store*:before {
+    accesses[effective_addr]++;
+}

--- a/tests/test_instrumentation/paper_eval.rs
+++ b/tests/test_instrumentation/paper_eval.rs
@@ -2,7 +2,7 @@ use crate::test_instrumentation::helper::{run_core_suite, setup_tests};
 use crate::util::setup_logger;
 
 #[test]
-fn instrument_with_paper_eval_branches_scripts() {
+fn branches() {
     setup_logger();
     let processed_scripts = setup_tests("paper_eval/branches");
     assert!(!processed_scripts.is_empty());
@@ -10,7 +10,7 @@ fn instrument_with_paper_eval_branches_scripts() {
     run_core_suite("paper_eval-branches", processed_scripts, true, true)
 }
 #[test]
-fn instrument_with_paper_eval_categories_scripts() {
+fn categories() {
     setup_logger();
     let processed_scripts = setup_tests("paper_eval/categories");
     assert!(!processed_scripts.is_empty());
@@ -18,7 +18,7 @@ fn instrument_with_paper_eval_categories_scripts() {
     run_core_suite("paper_eval-categories", processed_scripts, true, true)
 }
 #[test]
-fn instrument_with_paper_eval_hotness_scripts() {
+fn hotness() {
     setup_logger();
     let processed_scripts = setup_tests("paper_eval/hotness");
     assert!(!processed_scripts.is_empty());
@@ -26,7 +26,7 @@ fn instrument_with_paper_eval_hotness_scripts() {
     run_core_suite("paper_eval-hotness", processed_scripts, true, true)
 }
 #[test]
-fn instrument_with_paper_eval_ins_count_scripts() {
+fn ins_count() {
     setup_logger();
     let processed_scripts = setup_tests("paper_eval/ins_count");
     assert!(!processed_scripts.is_empty());
@@ -35,10 +35,37 @@ fn instrument_with_paper_eval_ins_count_scripts() {
 }
 
 #[test]
-fn instrument_with_paper_eval_cache_sim_scripts() {
+fn cache_sim() {
     setup_logger();
     let processed_scripts = setup_tests("paper_eval/cache_sim");
     assert!(!processed_scripts.is_empty());
 
     run_core_suite("paper_eval-cache_sim", processed_scripts, true, true)
+}
+
+#[test]
+fn ins_coverage() {
+    setup_logger();
+    let processed_scripts = setup_tests("paper_eval/ins_coverage");
+    assert!(!processed_scripts.is_empty());
+
+    run_core_suite("paper_eval-ins_coverage", processed_scripts, true, true)
+}
+
+#[test]
+fn mem_access_tracing() {
+    setup_logger();
+    let processed_scripts = setup_tests("paper_eval/mem_access_tracing");
+    assert!(!processed_scripts.is_empty());
+
+    run_core_suite("paper_eval-mem_access", processed_scripts, true, true)
+}
+
+#[test]
+fn call_graph() {
+    setup_logger();
+    let processed_scripts = setup_tests("paper_eval/call_graph");
+    assert!(!processed_scripts.is_empty());
+
+    run_core_suite("paper_eval-call_graph", processed_scripts, false, true)
 }

--- a/whamm_core/src/maps/mod.rs
+++ b/whamm_core/src/maps/mod.rs
@@ -359,8 +359,10 @@ impl MapOperations for AnyMap {
         None
     }
     fn dump_map(&self) -> String {
+        println!("dump_map");
         match self {
             AnyMap::i32_i32_Map(ref map) => {
+                println!("dump_map::i32_i32_Map");
                 let mut result = String::new();
 
                 // sort to make flush deterministic
@@ -377,6 +379,7 @@ impl MapOperations for AnyMap {
                 result
             }
             AnyMap::tuple_i32_Map(ref map) => {
+                println!("dump_map::tuple_i32_Map");
                 let mut result = String::new();
 
                 // sort to make flush deterministic
@@ -393,6 +396,7 @@ impl MapOperations for AnyMap {
                 result
             }
             AnyMap::i32_string_Map(ref map) => {
+                println!("dump_map::i32_string_Map");
                 debug!("DEBUG: dumping i32_string_Map...");
                 let mut result = String::new();
 
@@ -410,6 +414,7 @@ impl MapOperations for AnyMap {
                 result
             }
             AnyMap::string_i32_Map(ref map) => {
+                println!("dump_map::string_i32_Map");
                 debug!("DEBUG: dumping string_i32_Map...");
                 let mut result = String::new();
 
@@ -426,7 +431,7 @@ impl MapOperations for AnyMap {
                 }
                 result
             }
-            _ => "Not implemented".to_string(),
+            _ => format!("Not implemented: dump_map"),
         }
     }
 }
@@ -463,11 +468,17 @@ pub enum TupleVariant {
 
 impl TupleVariant {
     pub fn dump_tuple(&self) -> String {
+        println!("dump_tuple");
         match self {
+            TupleVariant::i32_i32(a, b) => {
+                println!("dump_tuple::i32_i32");
+                format!("({}, {})", a, b)
+            }
             TupleVariant::i32_i32_i32(a, b, c) => {
+                println!("dump_tuple::i32_i32_i32");
                 format!("({}, {}, {})", a, b, c)
             }
-            _ => "Not implemented".to_string(),
+            _ => format!("Not implemented: dump_tuple"),
         }
     }
 }
@@ -882,6 +893,10 @@ pub fn insert_string_i32(id: i32, key_offset: *const u8, key_length: usize, val:
     }
 }
 #[no_mangle]
+pub fn insert_i32i32tuple_i32(id: i32, key0: i32, key1: i32, value: i32) {
+    insert_tuple_i32_inner(id, TupleVariant::i32_i32(key0, key1), value);
+}
+#[no_mangle]
 pub fn insert_i32i32i32tuple_i32(id: i32, key0: i32, key1: i32, key2: i32, value: i32) {
     insert_tuple_i32_inner(id, TupleVariant::i32_i32_i32(key0, key1, key2), value);
 }
@@ -903,6 +918,10 @@ pub fn get_string_i32(id: i32, key_offset: *const u8, key_length: usize) -> i32 
     get_i32(id, &key)
 }
 #[no_mangle]
+pub fn get_i32i32tuple_i32(id: i32, key0: i32, key1: i32) -> i32 {
+    get_i32(id, &Box::new(TupleVariant::i32_i32(key0, key1)))
+}
+#[no_mangle]
 pub fn get_i32i32i32tuple_i32(id: i32, key0: i32, key1: i32, key2: i32) -> i32 {
     get_i32(id, &Box::new(TupleVariant::i32_i32_i32(key0, key1, key2)))
 }
@@ -912,9 +931,14 @@ pub fn get_i32i32i32tuple_i32(id: i32, key0: i32, key1: i32, key2: i32) -> i32 {
 #[no_mangle]
 pub fn print_map(id: i32) {
     let binding = MY_MAPS.lock().unwrap();
+
+    println!("BEFORE");
     if let Some(map) = binding.get(&id) {
+        println!("SOME");
         print!("{}", map.dump_map())
     } else {
+        println!("NONE");
         panic!("Could not find map with ID: {}", id)
     }
+    println!("AFTER");
 }


### PR DESCRIPTION
- [ ] ** Memory Access Tracing The analysis tracks all memory accesses and stores them for a later off-line analysis, e.g., to detect cache-unfriendly access patterns.
            - [ ] TODO: Go back and override the flush to make the CSV output better
            - [ ] TODO: Figure out why wizard and rewriting are different for cf.wasm
            - [x] NOW: Can just implement like this (also counts number of times the memory address is accessed: `accesses[addr]++` with an unshared report var, no need to store whether writing since you’d know the opcode
        - [ ] Loop Trace Profiling: See example in wizard
            - [ ] Compile prefix-trie to wasm and reuse ben’s implementation!
            - [ ] Will need to override report logic for this!
        - [ ] Basic Block Profiling A classic dynamic analysis [12] that counts how often each function, block, and loop is executed, which is useful, e.g., for finding “hot” code.
            - [ ] https://dl.acm.org/doi/10.5555/62504.62511
            - [ ] TODO: Need to create a basic block iterator of sorts in both targets, see: https://github.com/titzer/wizard-engine/blob/master/src/monitors/BlocksMonitor.v3
        - [ ] Instruction and Branch Coverage These analyses record for each instruction and branch, respectively, whether it is executed, which is useful to assess the quality of tests.
            - [ ] Instruction Coverage — via basic blocks
                - [ ] TODO: Need to create a basic block iterator of sorts in both targets, see: https://github.com/titzer/wizard-engine/blob/master/src/monitors/BlocksMonitor.v3
            - [ ] Instruction Coverage — via BOTH && remove after done
                - [ ] TODO: Need to call the remove API (how to add to API?)
            - [x] NOW: Instruction Coverage — at every point (easy)
            - [x] Branch Coverage
        - [ ] Call Graph Analysis This analysis creates a dynamic call graph, including indirect calls and calls between functions that are neither imported nor exported. Call graphs are the basis of various other analyses, e.g., to find dynamically dead code or to reverse-engineer malware.
            - [ ] TODO: add support for pulling call target (consider call_ref and call_indirect), not sure how to do call_ref in static side…
            - [ ] Can just implement like this (also counts number of times the edge is executed: `graph[(from, to)]++`
            - [ ] Instrument function entry (if in call_ref or call_indirect, set boolean, on function entry, save target and clear boolean)