### PR TITLE
Add support for `wat`  in the instr command

### DIFF
--- a/src/common/instr.rs
+++ b/src/common/instr.rs
@@ -58,7 +58,15 @@ pub fn run_with_path(
     config: Config,
 ) -> Result<Vec<u8>, Box<ErrorGen>> {
     let buff = if !config.as_monitor_module {
-        std::fs::read(app_wasm_path).unwrap()
+        let raw = std::fs::read(&app_wasm_path).unwrap();
+        match wat::parse_bytes(&raw) {
+            Ok(bytes) => bytes.into_owned(),
+            Err(error) => {
+                let mut err = ErrorGen::new(script_path.clone(), "".to_string(), max_errors);
+                err.add_instr_error(&format!("Failed to parse app {}: {}", app_wasm_path, error));
+                return Err(Box::new(err));
+            }
+        }
     } else {
         vec![]
     };


### PR DESCRIPTION
This change uses `wat::parse_bytes` to parse the the application binary passed to the `instr`  command. `wat::parse_bytes` will either accept the text format or the binary format. This makes it easier to inspect the transformations applied by whamm to small programs using the text format.

Ref: https://docs.rs/wat/latest/wat/fn.parse_bytes.html